### PR TITLE
return unlisten function to unlisten on client side

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -106,7 +106,7 @@ const nestedProxy = (
 
             const event_name = nested_path.join('.')
             return async (listener: (args: unknown) => void) => {
-              await listen(
+              return await listen(
                 TAURPC_EVENT_NAME,
                 createEventHandlder(event_name, listener, args_map),
               )


### PR DESCRIPTION
hi! i found this package and found it easier to implement than rspc, given the docs are out of date currently. 
one bug i ran into is that you can't unlisten from events on the client side because undefined is currently being returned. 

i added this return and patched it locally and it works now for me. 

thanks for this package! 🫰