### PR TITLE
feat(export_types): only export types on tauri dev

### DIFF
--- a/taurpc/src/lib.rs
+++ b/taurpc/src/lib.rs
@@ -286,7 +286,7 @@ impl<R: Runtime> Router<R> {
     ///      .expect("error while running tauri application");
     /// ```
     pub fn into_handler(self) -> impl Fn(Invoke<R>) -> bool {
-        #[cfg(debug_assertions)] // Only export in development builds
+        #[cfg(dev)] // Only export when using tauri dev
         export_types(
             self.export_path,
             self.args_map_json.clone(),


### PR DESCRIPTION
This will allow using the debug build without panicking when trying to export types (at least on macOS).

Today, I cannot use a build created with `tauri build --debug` because `cfg(debug_assertions)` is trying to export_types on the production debug build.

Using dev, ensure we are exporting only on tauri dev command.

[Tauri v2 Debug](https://v2.tauri.app/fr/develop/debug/)