### PR TITLE
Allow sync methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,35 @@ taurpc::Exporter::new()
     .unwrap();
 ```
 
+# Sync methods
+
+Methods are `async` by default, but you can also declare them without `async`. Sync methods respond inline instead of spawning on tauri's async runtime, the same way tauri handles non-async commands, which makes them a good fit for quick CPU-only procedures.
+
+```rust
+#[taurpc::procedures]
+trait Api {
+    fn sync_method() -> String;
+
+    async fn async_method() -> String;
+}
+
+#[derive(Clone)]
+struct ApiImpl;
+
+#[taurpc::resolvers]
+impl Api for ApiImpl {
+    fn sync_method(self) -> String {
+        "sync response".to_string()
+    }
+
+    async fn async_method(self) -> String {
+        "async response".to_string()
+    }
+}
+```
+
+On the frontend nothing changes, the generated client still returns a `Promise`. Sync methods run on the thread that receives the request, so anything slow or blocking should stay `async`, see the [Tauri guides](https://v2.tauri.app/develop/calling-rust/#async-commands) for more details.
+
 # Extra options for procedures
 
 Inside your procedures trait you can add attributes to the defined methods. This can be used to ignore or rename a method. Renaming will change the name of the procedure on the frontend.
@@ -412,7 +441,7 @@ await taurpc.update((update) => {
 - [x] Custom error handling
 - [x] Typed outputs
 - [x] Async methods - [async traits👀](https://blog.rust-lang.org/inside-rust/2023/05/03/stabilizing-async-fn-in-trait.html)
-  - [ ] Allow sync methods
+  - [x] Allow sync methods
 - [x] Calling the frontend
 - [x] Renaming event trigger struct
 - [x] Send event to specific window

--- a/example/src-tauri/src/main.rs
+++ b/example/src-tauri/src/main.rs
@@ -55,6 +55,9 @@ trait Api {
     /// test result
     async fn test_result(user: User) -> Result<User, Error>;
 
+    /// Sync methods respond inline, without spawning on the async runtime
+    fn test_sync(input: String) -> String;
+
     // #[taurpc(skip)]
     async fn with_sleep();
 
@@ -124,6 +127,10 @@ impl Api for ApiImpl {
     async fn test_result(self, user: User) -> Result<User, Error> {
         Err(Error::Other("Some error message".to_string()))
         // Ok(user)
+    }
+
+    fn test_sync(self, input: String) -> String {
+        input.to_uppercase()
     }
 
     async fn with_sleep(self) {

--- a/example/src/lib/bindings.ts
+++ b/example/src/lib/bindings.ts
@@ -48,9 +48,9 @@ export type User = {
 	/**  The user's last name */
 	last_name: string,
 };
-const ARGS_MAP = {"":{"ev":["updated_value"],"get_app_handle":[],"get_webview_window":[],"get_window":[],"method_with_alias":[],"multiple_args":["arg","arg2"],"phase_specific_rename":["input"],"test_bigint":["num"],"test_io":["_user"],"test_option":[],"test_result":["user"],"update_state":["new_value"],"vec_test":["arg"],"with_channel":["on_event"],"with_sleep":[]},"api.ui":{"test_ev":[],"trigger":[]},"error_testing":{"test_enum_error":["fail"],"test_string_error":["fail"],"test_struct_error":["fail"],"test_thiserror_error":["fail"],"test_with_channel":["fail","on_update"]},"events":{"multiple_args":["arg1","arg2"],"state_changed":["new_state"],"test_ev":[],"vec_test":["args"]}};
+const ARGS_MAP = {"":{"ev":["updated_value"],"get_app_handle":[],"get_webview_window":[],"get_window":[],"method_with_alias":[],"multiple_args":["arg","arg2"],"phase_specific_rename":["input"],"test_bigint":["num"],"test_io":["_user"],"test_option":[],"test_result":["user"],"test_sync":["input"],"update_state":["new_value"],"vec_test":["arg"],"with_channel":["on_event"],"with_sleep":[]},"api.ui":{"test_ev":[],"trigger":[]},"error_testing":{"test_enum_error":["fail"],"test_string_error":["fail"],"test_struct_error":["fail"],"test_thiserror_error":["fail"],"test_with_channel":["fail","on_update"]},"events":{"multiple_args":["arg1","arg2"],"state_changed":["new_state"],"test_ev":[],"vec_test":["args"]}};
 
-const RESULT_MAP = {"":{"ev":false,"get_app_handle":false,"get_webview_window":false,"get_window":false,"method_with_alias":false,"multiple_args":false,"phase_specific_rename":false,"test_bigint":false,"test_io":false,"test_option":false,"test_result":true,"update_state":false,"vec_test":false,"with_channel":false,"with_sleep":false},"api.ui":{"test_ev":false,"trigger":false},"error_testing":{"test_enum_error":true,"test_string_error":true,"test_struct_error":true,"test_thiserror_error":true,"test_with_channel":true},"events":{"multiple_args":false,"state_changed":false,"test_ev":false,"vec_test":false}};
+const RESULT_MAP = {"":{"ev":false,"get_app_handle":false,"get_webview_window":false,"get_window":false,"method_with_alias":false,"multiple_args":false,"phase_specific_rename":false,"test_bigint":false,"test_io":false,"test_option":false,"test_result":true,"test_sync":false,"update_state":false,"vec_test":false,"with_channel":false,"with_sleep":false},"api.ui":{"test_ev":false,"trigger":false},"error_testing":{"test_enum_error":true,"test_string_error":true,"test_struct_error":true,"test_thiserror_error":true,"test_with_channel":true},"events":{"multiple_args":false,"state_changed":false,"test_ev":false,"vec_test":false}};
 
 export type Router = {
 	"": {
@@ -71,6 +71,8 @@ export type Router = {
 		test_option: () => Promise<null>,
 		/**  test result */
 		test_result: (user: User) => Promise<TauRpcResult<User, Error>>,
+		/**  Sync methods respond inline, without spawning on the async runtime */
+		test_sync: (input: string) => Promise<string>,
 		/**  Update the state */
 		update_state: (newValue: string) => Promise<void>,
 		vec_test: (arg: string[]) => Promise<void>,

--- a/taurpc/Cargo.toml
+++ b/taurpc/Cargo.toml
@@ -36,3 +36,6 @@ tauri = { version = "2.10.2", features = ["specta"] }
 taurpc-macros = { path = "./taurpc-macros", version = "=0.8.2" }
 tokio = { version = "1", features = ["full"] }
 specta-util = "0.0.12"
+
+[dev-dependencies]
+tauri = { version = "2.10.2", features = ["test"] }

--- a/taurpc/taurpc-macros/src/generator.rs
+++ b/taurpc/taurpc-macros/src/generator.rs
@@ -69,6 +69,7 @@ impl ProceduresGenerator<'_> {
                     args,
                     generics,
                     attrs,
+                    is_async,
                     span,
                     ..
                 },
@@ -78,9 +79,18 @@ impl ProceduresGenerator<'_> {
                 if attrs.is_event {
                     return None;
                 }
+                let passthrough_attrs = &attrs.passthrough_attrs;
+
+                // sync methods don't need a future type, they return their output directly
+                if !is_async {
+                    return Some(quote_spanned! {*span=>
+                        #( #passthrough_attrs )*
+                        fn #ident #generics(self, #( #args ),*) -> #output_ty;
+                    });
+                }
+
                 let ty_doc = format!("The response future returned by [`{trait_ident}::{ident}`].");
                 let future_type_ident = method_fut_ident(ident);
-                let passthrough_attrs = &attrs.passthrough_attrs;
 
                 Some(quote_spanned! {*span=>
                     #[allow(non_camel_case_types)]
@@ -193,16 +203,24 @@ impl ProceduresGenerator<'_> {
 
         let outputs = methods
             .iter()
-            .filter_map(|IpcMethod { ident, attrs, .. }| {
-                if attrs.is_event {
-                    return None;
-                }
-                let future_ident = method_fut_ident(ident);
+            .filter_map(
+                |IpcMethod {
+                     ident,
+                     attrs,
+                     is_async,
+                     ..
+                 }| {
+                    // events don't have resolvers and sync methods don't return futures
+                    if attrs.is_event || !is_async {
+                        return None;
+                    }
+                    let future_ident = method_fut_ident(ident);
 
-                Some(quote! {
-                    #ident(<P as #trait_ident>::#future_ident)
-                })
-            })
+                    Some(quote! {
+                        #ident(<P as #trait_ident>::#future_ident)
+                    })
+                },
+            )
             .collect::<Vec<_>>();
 
         // If there are no commands, there are no future outputs and the generic P will be unused resulting in errors.
@@ -212,7 +230,11 @@ impl ProceduresGenerator<'_> {
 
         let method_idents = methods
             .iter()
-            .filter(|IpcMethod { attrs, .. }| !attrs.is_event)
+            .filter(
+                |IpcMethod {
+                     attrs, is_async, ..
+                 }| !attrs.is_event && *is_async,
+            )
             .map(|IpcMethod { ident, .. }| ident);
 
         quote! {
@@ -265,6 +287,7 @@ impl ProceduresGenerator<'_> {
                     ident,
                     args,
                     attrs,
+                    is_async,
                     span,
                     ..
                 },
@@ -276,6 +299,16 @@ impl ProceduresGenerator<'_> {
                 let method_call = quote_spanned!(*span=> #trait_ident::#ident(
                     self.methods, #( #args.unwrap() ),*
                 ));
+
+                // sync methods respond inline without going through the async runtime,
+                // the same way tauri handles non-async commands
+                if !is_async {
+                    return Some(quote! { stringify!(#proc_name) => {
+                        let res = #method_call;
+                        let kind = (&res).blocking_kind();
+                        kind.block(res, #resolver);
+                    }});
+                }
 
                 Some(quote! { stringify!(#proc_name) => {
                     #resolver.respond_async_serialized(async move {

--- a/taurpc/taurpc-macros/src/lib.rs
+++ b/taurpc/taurpc-macros/src/lib.rs
@@ -92,7 +92,8 @@ pub fn procedures(attrs: TokenStream, item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Transforms all methods to return `Pin<Box<Future<Output = ...>>>`, async traits are not supported.
+/// Transforms async methods to return `Pin<Box<Future<Output = ...>>>`, async traits are not supported.
+/// Sync methods are passed through unchanged.
 #[proc_macro_attribute]
 pub fn resolvers(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut item = syn::parse_macro_input!(item as ItemImpl);

--- a/taurpc/taurpc-macros/src/proc.rs
+++ b/taurpc/taurpc-macros/src/proc.rs
@@ -27,6 +27,8 @@ pub struct IpcMethod {
     pub args: Vec<Arg>,
     pub generics: Generics,
     pub attrs: MethodAttrs,
+    /// Async methods resolve on tauri's async runtime, sync methods respond inline.
+    pub is_async: bool,
     /// Span of the method signature, used for better error reporting
     pub span: Span,
 }
@@ -109,8 +111,8 @@ impl Parse for IpcMethod {
     fn parse(input: ParseStream) -> parse::Result<Self> {
         let attrs = MethodAttrs::parse(input)?;
 
-        let async_token = <Token![async]>::parse(input)?;
-        <Token![fn]>::parse(input)?;
+        let async_token: Option<Token![async]> = input.parse()?;
+        let fn_token = <Token![fn]>::parse(input)?;
 
         let ident: Ident = input.parse()?;
         let generics: Generics = input.parse()?;
@@ -136,8 +138,8 @@ impl Parse for IpcMethod {
         let output = input.parse()?;
         <Token![;]>::parse(input)?;
 
-        // Capture the span from async token (start of signature), fallback to ident span
-        let span = async_token.span;
+        // Capture the span from async token (start of signature), fallback to fn token span
+        let span = async_token.map(|token| token.span).unwrap_or(fn_token.span);
 
         Ok(IpcMethod {
             ident,
@@ -145,6 +147,7 @@ impl Parse for IpcMethod {
             args,
             generics,
             attrs,
+            is_async: async_token.is_some(),
             span,
         })
     }

--- a/taurpc/tests/sync_procedures.rs
+++ b/taurpc/tests/sync_procedures.rs
@@ -1,0 +1,132 @@
+//! Sync procedures respond inline without going through the async runtime,
+//! and can be mixed with async procedures in the same trait.
+
+use serde_json::json;
+use tauri::ipc::{CallbackFn, InvokeBody, InvokeResponseBody};
+use tauri::test::{
+    INVOKE_KEY, MockRuntime, get_ipc_response, mock_builder, mock_context, noop_assets,
+};
+use tauri::webview::InvokeRequest;
+
+#[taurpc::procedures]
+trait Api {
+    fn sync_greet(name: String) -> String;
+
+    fn sync_result(fail: bool) -> Result<String, String>;
+
+    async fn async_greet(name: String) -> String;
+}
+
+#[derive(Clone)]
+struct ApiImpl;
+
+#[taurpc::resolvers]
+impl Api for ApiImpl {
+    fn sync_greet(self, name: String) -> String {
+        format!("Hello, {name}!")
+    }
+
+    fn sync_result(self, fail: bool) -> Result<String, String> {
+        if fail {
+            Err("expected failure".to_string())
+        } else {
+            Ok("success".to_string())
+        }
+    }
+
+    async fn async_greet(self, name: String) -> String {
+        format!("Hello, {name}!")
+    }
+}
+
+// Traits without any async methods should also work.
+#[taurpc::procedures]
+trait SyncOnly {
+    fn ping() -> String;
+}
+
+#[derive(Clone)]
+struct SyncOnlyImpl;
+
+#[taurpc::resolvers]
+impl SyncOnly for SyncOnlyImpl {
+    fn ping(self) -> String {
+        "pong".to_string()
+    }
+}
+
+fn call<F>(
+    handler: F,
+    cmd: &str,
+    body: serde_json::Value,
+) -> Result<InvokeResponseBody, serde_json::Value>
+where
+    F: Fn(tauri::ipc::Invoke<MockRuntime>) -> bool + Send + Sync + 'static,
+{
+    let app = mock_builder()
+        .invoke_handler(handler)
+        .build(mock_context(noop_assets()))
+        .unwrap();
+    let webview = tauri::WebviewWindowBuilder::new(&app, "main", Default::default())
+        .build()
+        .unwrap();
+
+    get_ipc_response(
+        &webview,
+        InvokeRequest {
+            cmd: cmd.into(),
+            callback: CallbackFn(0),
+            error: CallbackFn(1),
+            url: if cfg!(any(windows, target_os = "android")) {
+                "http://tauri.localhost"
+            } else {
+                "tauri://localhost"
+            }
+            .parse()
+            .unwrap(),
+            body: InvokeBody::Json(body),
+            headers: Default::default(),
+            invoke_key: INVOKE_KEY.to_string(),
+        },
+    )
+}
+
+fn call_api(cmd: &str, body: serde_json::Value) -> Result<InvokeResponseBody, serde_json::Value> {
+    call(
+        taurpc::create_ipc_handler(ApiImpl.into_handler()),
+        cmd,
+        body,
+    )
+}
+
+#[test]
+fn sync_procedure_responds() {
+    let response = call_api("TauRPC__sync_greet", json!({ "name": "world" })).unwrap();
+    assert_eq!(response.deserialize::<String>().unwrap(), "Hello, world!");
+}
+
+#[test]
+fn sync_procedure_result() {
+    let response = call_api("TauRPC__sync_result", json!({ "fail": false })).unwrap();
+    assert_eq!(response.deserialize::<String>().unwrap(), "success");
+
+    let error = call_api("TauRPC__sync_result", json!({ "fail": true })).unwrap_err();
+    assert_eq!(error, json!("expected failure"));
+}
+
+#[test]
+fn async_procedure_still_responds() {
+    let response = call_api("TauRPC__async_greet", json!({ "name": "world" })).unwrap();
+    assert_eq!(response.deserialize::<String>().unwrap(), "Hello, world!");
+}
+
+#[test]
+fn sync_only_trait_responds() {
+    let response = call(
+        taurpc::create_ipc_handler(SyncOnlyImpl.into_handler()),
+        "TauRPC__ping",
+        json!({}),
+    )
+    .unwrap();
+    assert_eq!(response.deserialize::<String>().unwrap(), "pong");
+}


### PR DESCRIPTION
This one has been sitting on the README checklist for a while: procedures no longer have to be `async`.

Leave the keyword off a method and the generated handler responds inline on tauri's own non-async command path (`blocking_kind`/`block`) instead of `respond_async_serialized` plus the executor round-trip. Async methods expand exactly as before, the two mix freely in one trait, and `#[taurpc::resolvers]` was already passing sync fns through untouched, so an impl just drops the keyword. Nothing changes on the frontend, the client still gets a `Promise`.

The nudge for me is a lighting controller that pushes fader moves over IPC at high frequency, where the spawn round-trip is measurable: through tauri's mock runtime on my machine, a sync procedure responds at raw `#[tauri::command]` cost (~1.1us median) vs ~8.4us for the async path. Same tradeoff tauri documents for its own sync commands, the method runs on the thread that receives the request, so slow work should stay `async` (noted in the README section).

Also in the diff: a `tests/` dir with mock-runtime round-trip tests (mixed trait, all-sync trait, `Result` errors), a `test_sync` example method with regenerated bindings, and the ticked checkbox. Happy to adjust anything, and thanks again for this library. :)
